### PR TITLE
Refactoring into microservice architecture

### DIFF
--- a/chateval/templates/splash.html
+++ b/chateval/templates/splash.html
@@ -48,7 +48,7 @@
           
           {% for baseline in baselines %}
           <div class="column is-half" >
-            <a href="/model/{{ baseline.model }}">
+            <a href="/model?model_id={{ baseline.model.model_id }}">
               <div class="box">
                 <article class="media">
                   <div class="media-content">

--- a/eval/scripts/automatic/automatic_evaluations.py
+++ b/eval/scripts/automatic/automatic_evaluations.py
@@ -10,7 +10,7 @@ def run_automatic_evaluation(model, submission, model_responses, evalset):
     baseline_responses = [message['response'] for message in get_baseline_messages(evalset_id)]
     responses = json({'model_responses': model_responses, 'baseline_responses': baseline_responses})
 
-    r = requests.post('http://' + os.environ['EVAL_LOCATION'] + '/', json=responses).json()
+    r = requests.post(os.environ['EVAL_LOCATION'], json=responses).json()
 
     AutomaticEvaluation.objects.bulk_create([
         AutomaticEvaluation(metric=Metric.objects.get(metric_id=1), model=model, evaluationdataset=evalset, value=r['avg_len'], model_submission=submission),

--- a/eval/scripts/automatic/automatic_evaluations.py
+++ b/eval/scripts/automatic/automatic_evaluations.py
@@ -1,35 +1,22 @@
-from pymagnitude import Magnitude
+import requests
+import os
+from json import dumps as json
 from orm.models import AutomaticEvaluation, Metric
-from orm.scripts import get_messages, get_baseline_messages
-from .auto_eval_utils import avg_len, distinct_1, distinct_2, greedy_match, greedy_score, extrema_score, average_embedding_score
-
-class Word2Vec:
-    def __init__(self, vectors):
-        self.vectors = vectors
-        self.layer1_size = self.vectors.dim
-    
-    def __getitem__(self, word):
-        return self.vectors.query(word)
-    
-    def __contains__(self, word):
-        return word in self.vectors
-    
-    def dim(self):
-        return self.vectors.dim
+from orm.scripts import get_baseline_messages
 
 def run_automatic_evaluation(model, submission, model_responses, evalset):
     model_id = model.model_id
     evalset_id = evalset.pk
     baseline_responses = [message['response'] for message in get_baseline_messages(evalset_id)]
+    responses = json({'model_responses': model_responses, 'baseline_responses': baseline_responses})
 
-    vectors = Magnitude('eval/scripts/files/google_news.magnitude')
-    w2v = Word2Vec(vectors)
+    r = requests.post('http://' + os.environ['EVAL_LOCATION'] + '/', json=responses).json()
 
     AutomaticEvaluation.objects.bulk_create([
-        AutomaticEvaluation(metric=Metric.objects.get(metric_id=1), model=model, evaluationdataset=evalset, value=avg_len(model_responses), model_submission=submission),
-        AutomaticEvaluation(metric=Metric.objects.get(metric_id=2), model=model, evaluationdataset=evalset, value=distinct_1(model_responses), model_submission=submission),
-        AutomaticEvaluation(metric=Metric.objects.get(metric_id=3), model=model, evaluationdataset=evalset, value=distinct_2(model_responses), model_submission=submission),
-        AutomaticEvaluation(metric=Metric.objects.get(metric_id=4), model=model, evaluationdataset=evalset, value=greedy_match(model_responses, baseline_responses, w2v)[0], model_submission=submission),
-        AutomaticEvaluation(metric=Metric.objects.get(metric_id=5), model=model, evaluationdataset=evalset, value=extrema_score(model_responses, baseline_responses, w2v)[0], model_submission=submission),
-        AutomaticEvaluation(metric=Metric.objects.get(metric_id=6), model=model, evaluationdataset=evalset, value=average_embedding_score(model_responses, baseline_responses, w2v)[0], model_submission=submission),
+        AutomaticEvaluation(metric=Metric.objects.get(metric_id=1), model=model, evaluationdataset=evalset, value=r['avg_len'], model_submission=submission),
+        AutomaticEvaluation(metric=Metric.objects.get(metric_id=2), model=model, evaluationdataset=evalset, value=r['distinct_1'], model_submission=submission),
+        AutomaticEvaluation(metric=Metric.objects.get(metric_id=3), model=model, evaluationdataset=evalset, value=r['distinct_2'], model_submission=submission),
+        AutomaticEvaluation(metric=Metric.objects.get(metric_id=4), model=model, evaluationdataset=evalset, value=r['greedy_match'], model_submission=submission),
+        AutomaticEvaluation(metric=Metric.objects.get(metric_id=5), model=model, evaluationdataset=evalset, value=r['extrema_score'], model_submission=submission),
+        AutomaticEvaluation(metric=Metric.objects.get(metric_id=6), model=model, evaluationdataset=evalset, value=r['average_embedding_score'], model_submission=submission),
     ])

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,6 @@ django-six==1.0.4
 django-storages==1.6.6
 docutils==0.14
 fasteners==0.14.1
-gensim==3.4.0
 gunicorn==19.8.1
 idna==2.7
 jmespath==0.9.3
@@ -29,8 +28,5 @@ screen==1.0.1
 six==1.11.0
 smart-open==1.5.7
 urllib3==1.23
-virtualenv==16.0.0
 xlwt==1.3.0
 xmltodict==0.11.0
-xxhash==1.0.1
-pymagnitude


### PR DESCRIPTION
Makes a request to [the Flask-based evaluation microservice](https://github.com/chateval/eval) instead of performing automatic evaluations in the Django application.

Additions:
- Cleaned up requirements to install packages/deploy faster
- Fixed UI